### PR TITLE
Linux Build Test

### DIFF
--- a/Sources/BinUtils.swift
+++ b/Sources/BinUtils.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreFoundation
 
 // MARK: protocol UnpackedType
 
@@ -58,7 +59,7 @@ extension Float64 : DataConvertible { }
 
 extension String {
     subscript (from:Int, to:Int) -> String {
-        return (self as NSString).substring(with: NSMakeRange(from, to-from))
+        return NSString(string: self).substring(with: NSMakeRange(from, to-from))
     }
 }
 
@@ -83,7 +84,7 @@ public func hexlify(_ data:Data) -> String {
     var byte: UInt8 = 0
     
     for i in 0 ..< data.count {
-        (data as NSData).getBytes(&byte, range: NSMakeRange(i, 1))
+        NSData(data: data).getBytes(&byte, range: NSMakeRange(i, 1))
         s = s.appendingFormat("%02x", byte)
     }
     
@@ -133,7 +134,7 @@ func isBigEndianFromMandatoryByteOrderFirstCharacter(_ format:String) -> Bool {
     
     guard let firstChar = format.characters.first else { assertionFailure("empty format"); return false }
     
-    let s = String(firstChar) as NSString
+    let s = NSString(string: String(firstChar))
     let c = s.substring(to: 1)
     
     if c == "@" { assertionFailure("native size and alignment is unsupported") }
@@ -338,7 +339,7 @@ public func pack(_ format:String, _ objects:[Any], _ stringEncoding:String.Encod
 
 public func unpack(_ format:String, _ data:Data, _ stringEncoding:String.Encoding=String.Encoding.windowsCP1252) throws -> [Unpackable] {
     
-    assert(Int(OSHostByteOrder()) == OSLittleEndian, "\(#file) assumes little endian, but host is big endian")
+    assert(CFByteOrderGetCurrent() == 1 /* CFByteOrderLittleEndian */, "\(#file) assumes little endian, but host is big endian")
     
     let isBigEndian = isBigEndianFromMandatoryByteOrderFirstCharacter(format)
     

--- a/Tests/BinUtilsTests/BinUtilsTests.swift
+++ b/Tests/BinUtilsTests/BinUtilsTests.swift
@@ -6,16 +6,17 @@
 //  Copyright © 2016 Nicolas Seriot. All rights reserved.
 //
 
+import Foundation
 import XCTest
 @testable import BinUtils
 
 class BinUtilsTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
@@ -28,9 +29,9 @@ class BinUtilsTests: XCTestCase {
 
     func testHexlifyUnhexlify() {
         let s1 = "ABcdEF"
-        
+
         let s2 = hexlify(unhexlify(s1)!)
-        
+
         XCTAssertEqual(s1.lowercased(), s2)
     }
 
@@ -39,7 +40,7 @@ class BinUtilsTests: XCTestCase {
         if let f = FileHandle(forReadingAtPath: path) {
             let a = try! unpack("<2H", f.readData(ofLength: 4))
             f.closeFile()
-         
+
             XCTAssertEqual(a[0] as? Int, 64207)
             XCTAssertEqual(a[1] as? Int, 65261)
         } else {
@@ -49,7 +50,7 @@ class BinUtilsTests: XCTestCase {
 
     func testUnpack1() {
         let a = try! unpack(">hBsf", unhexlify("050001413fc00000")!)
-        
+
         XCTAssertEqual(a[0] as? Int, 1280)
         XCTAssertEqual(a[1] as? Int, 1)
         XCTAssertEqual(a[2] as? String, "A")
@@ -58,7 +59,7 @@ class BinUtilsTests: XCTestCase {
 
     func testUnpack2() {
         let a = try! unpack("<I 2s f", unhexlify("010000006162cdcc2c40")!)
-        
+
         XCTAssertEqual(a[0] as? Int, 1)
         XCTAssertEqual(a[1] as? String, "ab")
         XCTAssertEqual(a[2] as? Double, 2.700000047683716)
@@ -66,7 +67,7 @@ class BinUtilsTests: XCTestCase {
 
     func testUnpack3() {
         let a = try! unpack("<2sss", unhexlify("41414141")!)
-        
+
         XCTAssertEqual(a[0] as? String, "AA")
         XCTAssertEqual(a[1] as? String, "A")
         XCTAssertEqual(a[2] as? String, "A")
@@ -76,7 +77,7 @@ class BinUtilsTests: XCTestCase {
         let a = try! unpack("<", Data())
         assert(a.count == 0)
     }
-    
+
     func testFormatSizes() {
 
         XCTAssertEqual(0, numberOfBytesInFormat(""))
@@ -87,7 +88,7 @@ class BinUtilsTests: XCTestCase {
         XCTAssertEqual(6, numberOfBytesInFormat(">5sb"))
         XCTAssertEqual(8, numberOfBytesInFormat(">hBsf"))
     }
-        
+
     func testPackLittleEndian() {
         let data = pack("<Ih", [1, 2])
         XCTAssertEqual(data, unhexlify("01000000 0200"))
@@ -127,12 +128,12 @@ class BinUtilsTests: XCTestCase {
         let data = pack("<2s2s", ["as", "df"])
         XCTAssertEqual(data, unhexlify("6173 6466"))
     }
-    
+
     func testPack() {
         let data = pack("<h2I3sf", [1, 2, 3, "asd", 0.5])
         XCTAssertEqual(data, unhexlify("0100 02000000 03000000 617364 0000003f"))
     }
-    
+
     func testPackUnpackNetworkOrder() {
         // http://effbot.org/librarybook/struct.htm
         let data = pack("!ihb", [1, 2, 3])
@@ -140,5 +141,31 @@ class BinUtilsTests: XCTestCase {
         XCTAssertEqual(a[0] as? Int, 1)
         XCTAssertEqual(a[1] as? Int, 2)
         XCTAssertEqual(a[2] as? Int, 3)
+    }
+}
+
+extension BinUtilsTests {
+    static var allTests: [
+        ( String, (BinUtilsTests) -> () throws -> Void )
+        ]
+    {
+        return [
+            ("testUnhexlify", testUnhexlify),
+            ("testHexlifyUnhexlify", testHexlifyUnhexlify),
+            ("testUnpack1", testUnpack1),
+            ("testUnpack2", testUnpack2),
+            ("testUnpack3", testUnpack3),
+            ("testUnpackNothing", testUnpackNothing),
+            ("testFormatSizes", testFormatSizes),
+            ("testPackLittleEndian", testPackLittleEndian),
+            ("testPackBigEndian", testPackBigEndian),
+            ("testPackWithPadding", testPackWithPadding),
+            ("testPackWithPaddingRepeat", testPackWithPaddingRepeat),
+            ("testPackWithRepeats", testPackWithRepeats),
+            ("testPackWithRepeatsPlusCharacter", testPackWithRepeatsPlusCharacter),
+            ("testPackString", testPackString),
+            ("testPack", testPack),
+            ("testPackUnpackNetworkOrder", testPackUnpackNetworkOrder),
+        ]
     }
 }


### PR DESCRIPTION
Fixed Linux build issues and added allTests var for Linux testing.

Some of the changes required to build on Linux are not what I would normally write, but I have found no other way to get them to build on Linux (hopefully in newer versions of Swift this can be fixed).

All the tests pass on macOS and all but the tests involving "A" or "a" in the unpack tests pass on linux. I'm looking into it, the A or a tests have nil in the result.

Linux test failure messages:

```
/root/s/BinUtils/Tests/BinUtilsTests/BinUtilsTests.swift:56: error: BinUtilsTests.testUnpack1 : XCTAssertEqual failed: ("nil") is not equal to ("Optional("A")") - 
/root/s/BinUtils/Tests/BinUtilsTests/BinUtilsTests.swift:64: error: BinUtilsTests.testUnpack2 : XCTAssertEqual failed: ("nil") is not equal to ("Optional("ab")") - 
/root/s/BinUtils/Tests/BinUtilsTests/BinUtilsTests.swift:71: error: BinUtilsTests.testUnpack3 : XCTAssertEqual failed: ("nil") is not equal to ("Optional("AA")") - 
/root/s/BinUtils/Tests/BinUtilsTests/BinUtilsTests.swift:72: error: BinUtilsTests.testUnpack3 : XCTAssertEqual failed: ("nil") is not equal to ("Optional("A")") - 
/root/s/BinUtils/Tests/BinUtilsTests/BinUtilsTests.swift:73: error: BinUtilsTests.testUnpack3 : XCTAssertEqual failed: ("nil") is not equal to ("Optional("A")") - 
```